### PR TITLE
Add mark 'no_default_loop'

### DIFF
--- a/tests/test_test_with_custom_loop.py
+++ b/tests/test_test_with_custom_loop.py
@@ -1,0 +1,15 @@
+import asyncio
+import pytest
+
+
+async def _coro():
+    await asyncio.sleep(0.1)
+    return "works"
+
+
+@pytest.mark.no_default_loop
+def test_with_custom_loop():
+    loop = asyncio.get_event_loop()
+    res = loop.run_until_complete(_coro())
+    assert res == "works"
+    loop.close()

--- a/tests/test_test_with_custom_loop.py
+++ b/tests/test_test_with_custom_loop.py
@@ -9,7 +9,7 @@ async def _coro():
 
 @pytest.mark.no_default_loop
 def test_with_custom_loop():
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     res = loop.run_until_complete(_coro())
     assert res == "works"
     loop.close()


### PR DESCRIPTION
Hi,
First of all, the library is great! :) It worked on almost all tests without changing a line of code. 

We have some non-async tests that manage the loop themselves (with `loop = asyncio.get_event_loop` and `loop.close()`). The problem is that after the running the test, the global loop is closed and all the remaining tests fail.

As a workaround, I added the marker `no_default_loop` that "hides" loop to prevent being closed in the test.

I'm open to other approaches.

Thank you