### PR TITLE
include a new command line option called --async-timeout

### DIFF
--- a/alt_pytest_asyncio/async_converters.py
+++ b/alt_pytest_asyncio/async_converters.py
@@ -43,7 +43,7 @@ def converted_async_test(test_tasks, func, timeout, *args, **kwargs):
 
 
 def _find_async_timeout(func, node):
-    timeout = float(node.config.getoption("async_timeout", None) or node.config.getini("async_timeout"))
+    timeout = float(node.config.getoption("default_async_timeout", None) or node.config.getini("default_async_timeout"))
 
     marker = node.get_closest_marker("async_timeout")
     if marker:

--- a/alt_pytest_asyncio/async_converters.py
+++ b/alt_pytest_asyncio/async_converters.py
@@ -43,7 +43,7 @@ def converted_async_test(test_tasks, func, timeout, *args, **kwargs):
 
 
 def _find_async_timeout(func, node):
-    timeout = float(node.config.getini("default_alt_async_timeout"))
+    timeout = float(node.config.getoption("async_timeout", None) or node.config.getini("async_timeout"))
 
     marker = node.get_closest_marker("async_timeout")
     if marker:

--- a/alt_pytest_asyncio/async_converters.py
+++ b/alt_pytest_asyncio/async_converters.py
@@ -43,7 +43,10 @@ def converted_async_test(test_tasks, func, timeout, *args, **kwargs):
 
 
 def _find_async_timeout(func, node):
-    timeout = float(node.config.getoption("default_async_timeout", None) or node.config.getini("default_async_timeout"))
+    timeout = float(
+        node.config.getoption("default_async_timeout", None)
+        or node.config.getini("default_async_timeout")
+    )
 
     marker = node.get_closest_marker("async_timeout")
     if marker:

--- a/alt_pytest_asyncio/plugin.py
+++ b/alt_pytest_asyncio/plugin.py
@@ -36,9 +36,7 @@ class AltPytestAsyncioPlugin:
             help="timeout in seconds before failing a test",
         )
         parser.addini(
-            "default_async_timeout",
-            "The default timeout for the mark.async_timeout",
-            default=5,
+            "default_async_timeout", "The default timeout for the mark.async_timeout", default=5,
         )
 
     @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -85,8 +83,10 @@ class AltPytestAsyncioPlugin:
             if timeout:
                 timeout = timeout.args[0]
             else:
-                timeout = float(pyfuncitem.config.getoption("default_async_timeout", None) or
-                                pyfuncitem.config.getini("default_async_timeout"))
+                timeout = float(
+                    pyfuncitem.config.getoption("default_async_timeout", None)
+                    or pyfuncitem.config.getini("default_async_timeout")
+                )
 
             o = pyfuncitem.obj
             pyfuncitem.obj = wraps(o)(partial(converted_async_test, self.test_tasks, o, timeout))

--- a/alt_pytest_asyncio/plugin.py
+++ b/alt_pytest_asyncio/plugin.py
@@ -28,8 +28,15 @@ class AltPytestAsyncioPlugin:
 
     def pytest_addoption(self, parser):
         """Add an option for default async timeouts"""
+        group = parser.getgroup("alt-pytest-asyncio options")
+        group.addoption(
+            "--async-timeout",
+            type=float,
+            dest="async_timeout",
+            help="timeout in seconds before failing a test",
+        )
         parser.addini(
-            "default_alt_async_timeout",
+            "async_timeout",
             "The default timeout for the mark.async_timeout",
             default=5,
         )
@@ -78,7 +85,8 @@ class AltPytestAsyncioPlugin:
             if timeout:
                 timeout = timeout.args[0]
             else:
-                timeout = float(pyfuncitem.config.getini("default_alt_async_timeout"))
+                timeout = float(pyfuncitem.config.getoption("async_timeout", None) or
+                                pyfuncitem.config.getini("async_timeout"))
 
             o = pyfuncitem.obj
             pyfuncitem.obj = wraps(o)(partial(converted_async_test, self.test_tasks, o, timeout))

--- a/alt_pytest_asyncio/plugin.py
+++ b/alt_pytest_asyncio/plugin.py
@@ -30,13 +30,13 @@ class AltPytestAsyncioPlugin:
         """Add an option for default async timeouts"""
         group = parser.getgroup("alt-pytest-asyncio options")
         group.addoption(
-            "--async-timeout",
+            "--default-async-timeout",
             type=float,
-            dest="async_timeout",
+            dest="default_async_timeout",
             help="timeout in seconds before failing a test",
         )
         parser.addini(
-            "async_timeout",
+            "default_async_timeout",
             "The default timeout for the mark.async_timeout",
             default=5,
         )

--- a/alt_pytest_asyncio/plugin.py
+++ b/alt_pytest_asyncio/plugin.py
@@ -85,8 +85,8 @@ class AltPytestAsyncioPlugin:
             if timeout:
                 timeout = timeout.args[0]
             else:
-                timeout = float(pyfuncitem.config.getoption("async_timeout", None) or
-                                pyfuncitem.config.getini("async_timeout"))
+                timeout = float(pyfuncitem.config.getoption("default_async_timeout", None) or
+                                pyfuncitem.config.getini("default_async_timeout"))
 
             o = pyfuncitem.obj
             pyfuncitem.obj = wraps(o)(partial(converted_async_test, self.test_tasks, o, timeout))


### PR DESCRIPTION
I'd like to propose the inclusion of a new command-line option to control the timeout. It'll be useful for debugging. Also, I changed `default_alt_async_timeout` to `async_timeout`. The former is too long and specific. Considering that there won't be another pytest plugin for asynchronous tests, it could be shorter.