### PR TITLE
asyncio: #10 shutdown_asyncgens

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ Changelog
     * Fix bug where it was possible for an async generator fixture to
       be cleaned up even if it was never started.
     * This library is now 3.7+ only
+    * Added an equivalent ``shutdown_asyncgen`` to the OverrideLoop helper
 
 0.5.4 - 26 January 2021
     * Added a ``--default-async-timeout`` option from the CLI. With many thanks

--- a/pylama.ini
+++ b/pylama.ini
@@ -2,7 +2,7 @@
 skip = */setup.py
 
 [pylama:tests/*]
-ignore = E225,E202,E211,E231,E226,W292,W291,E251,E122,E501,E701,E227,E305,E128,W391
+ignore = E225,E202,E211,E231,E226,W292,W291,E251,E122,E501,E701,E227,E305,E128,W391,C901
 
 [pylama:pyflakes]
 builtins = _


### PR DESCRIPTION
Ensure any async generators that are left running past
run_until_complete (essentially only if we get a KeyboardInterrupt that
stops the run_until_complete) then those are finalized properly

Note I don't use loop.shutdown_asyncgens sothat I can make the generator
handle an asyncio.CancelledError rather than a GeneratorExit