### PR TITLE
test: fix flaky test on slow machines

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -88,7 +88,7 @@ async it "shows correctly for failing fixtures", name, request, tmp_path_factory
     matcher.fnmatch_lines(expected.split("\n"))
 
 
-@pytest.mark.async_timeout(5)
+@pytest.mark.async_timeout(7)
 @pytest.mark.skipif(os.name == "nt", reason="Can't use async subprocess on windows")
 async it "cleans up tests properly on interrupt":
     directory = os.path.join(this_dir, "interrupt_test")
@@ -108,7 +108,7 @@ async it "cleans up tests properly on interrupt":
         stderr=subprocess.STDOUT,
     )
 
-    await asyncio.sleep(2)
+    await asyncio.sleep(4)
     p.send_signal(signal.SIGINT)
     await p.wait()
 


### PR DESCRIPTION
Send the interrupt a little later so that we won't end up interrupting it too early, which will cause the output mismatch.

I got the following result from a riscv64 board and emulator:

```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
/usr/lib/python3.11/unittest/__init__.py:93: KeyboardInterrupt
(to show a full traceback on KeyboardInterrupt use --full-trace)
```

```
============================= test session starts ==============================
platform linux -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0
rootdir: /build/python-alt-pytest-asyncio/src/alt-pytest-asyncio-release-0.7.0/tests/interrupt_test
configfile: pytest.ini
plugins: alt-pytest-asyncio-0.7.0, noseOfYeti-2.4.1
collected 5 items

tests/test_example.py .F

=================================== FAILURES ===================================
__________________________ test_bb_shows_failed_tests __________________________
tests/test_example.py:20: in test_bb_shows_failed_tests
    assert False, "NOOOOO"
E   AssertionError: NOOOOO
E   assert False
=========================== short test summary info ============================
FAILED tests/test_example.py::test_bb_shows_failed_tests - AssertionError: NO...
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
/usr/lib/python3.11/selectors.py:468: KeyboardInterrupt
(to show a full traceback on KeyboardInterrupt use --full-trace)
========================= 1 failed, 1 passed in 1.78s ==========================
```