### PR TITLE
Remove a namespace conflict that restricted parametrize names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,10 @@ generator fixtures.
 Changelog
 ---------
 
+0.8.1 - TBD
+    * Remove a namespace conflict that restricted what names could be used as
+      parametrize arguments.
+
 0.8.0 - 1 June 2024
     * Provide simple support for tests being aware of asyncio.Context
     * Remove support for python less than 3.11

--- a/alt_pytest_asyncio/async_converters.py
+++ b/alt_pytest_asyncio/async_converters.py
@@ -86,7 +86,7 @@ def convert_sync_gen_fixture(ctx, fixturedef):
     fixturedef.func = run_fixture
 
 
-def converted_async_test(ctx, test_tasks, func, timeout, *args, **kwargs):
+def converted_async_test(ctx, test_tasks, func, timeout, /, *args, **kwargs):
     """Used to replace async tests"""
     __tracebackhide__ = True
 

--- a/alt_pytest_asyncio/plugin.py
+++ b/alt_pytest_asyncio/plugin.py
@@ -89,11 +89,11 @@ class AltPytestAsyncioPlugin:
             def run_obj(*args, **kwargs):
                 try:
                     self.ctx.run(lambda: None)
-                    run = lambda func, *a, **kw: self.ctx.run(func, *a, **kw)
+                    run = lambda func: self.ctx.run(func)
                 except RuntimeError:
-                    run = lambda func, *a, **kw: func(*a, **kw)
+                    run = lambda func: func()
 
-                run(original, *args, **kwargs)
+                run(partial(original, *args, **kwargs))
 
             pyfuncitem.obj = run_obj
 

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -53,3 +53,13 @@ describe "A class":
 
     it "uses our fixtures", a_value_times_two:
         assert a_value_times_two == 2
+
+
+@pytest.mark.parametrize("func", [1])
+it "allows func as a parametrize", func:
+    assert func == 1
+
+
+@pytest.mark.parametrize("func", [1])
+async it "allows func as a parametrize for async too", func:
+    assert func == 1


### PR DESCRIPTION
Prior to this the arguments that were given to test functions were limited by other arguments used when passing them around.

This is fixed by the use of the syntax introduced in PEP 570 to ensure those arguments specific to the plugin are positional only

Fixes #17