### PR TITLE
Fix persisting fixture errors

### DIFF
--- a/alt_pytest_asyncio/base.py
+++ b/alt_pytest_asyncio/base.py
@@ -1,6 +1,6 @@
 import abc
 from collections.abc import Callable
-from typing import NoReturn
+from typing import NoReturn, Protocol
 
 
 class AsyncTimeout(abc.ABC):
@@ -15,6 +15,10 @@ class AsyncTimeout(abc.ABC):
 
     @abc.abstractmethod
     def raise_maybe(self, func: Callable[..., object]) -> None: ...
+
+
+class AsyncTimeoutMaker(Protocol):
+    def __call__(self) -> AsyncTimeout: ...
 
 
 class AsyncTimeoutProvider(abc.ABC):

--- a/alt_pytest_asyncio/converter.py
+++ b/alt_pytest_asyncio/converter.py
@@ -66,7 +66,9 @@ class Converter:
             return
 
         if hasattr(fixturedef.func, "__alt_asyncio_pytest_converted__"):
-            return
+            fixturedef.func = fixturedef.func.__alt_asyncio_pytest_original__  # type: ignore[misc,attr-defined]
+
+        original = fixturedef.func
 
         if inspect.iscoroutinefunction(fixturedef.func):
             async_timeout_maker = self._get_async_timeout_maker(
@@ -87,6 +89,7 @@ class Converter:
             self._convert_sync_fixture(fixturedef)
 
         fixturedef.func.__alt_asyncio_pytest_converted__ = True  # type: ignore[attr-defined]
+        fixturedef.func.__alt_asyncio_pytest_original__ = original  # type: ignore[attr-defined]
 
     def convert_pyfunc(self, pyfuncitem: pytest.Function) -> None:
         if inspect.iscoroutinefunction(pyfuncitem.obj):

--- a/alt_pytest_asyncio/converter.py
+++ b/alt_pytest_asyncio/converter.py
@@ -171,11 +171,10 @@ class Converter:
                     __tracebackhide__ = True
 
                     async_timeout.use_default_timeout()
-                    await self._async_runner(async_timeout, gen_obj.__anext__, (), {})
-                    if async_timeout.error is not None:
-                        if isinstance(async_timeout.error, StopAsyncIteration):
-                            async_timeout.error = None
-                    else:
+                    if not isinstance(async_timeout.error, StopAsyncIteration):
+                        await self._async_runner(async_timeout, gen_obj.__anext__, (), {})
+
+                    if async_timeout.error is None:
                         async_timeout.error = ValueError(
                             "Async generator fixture should only yield once"
                         )

--- a/alt_pytest_asyncio/plugin.py
+++ b/alt_pytest_asyncio/plugin.py
@@ -158,7 +158,7 @@ class LoadedAsyncTimeout(base.AsyncTimeout):
             if self.error:
                 raise self.error
 
-        if self.error:
+        if self.error and not isinstance(self.error, StopAsyncIteration):
             # Use a separate function so when --tb=short is not set we don't get
             # this entire function in the output
             raise_error()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,12 @@ generator fixtures.
 Changelog
 ---------
 
+.. _release-0.9.3:
+
+0.9.3 - TBD
+    * Fixed a bug where fixture errors would persist across multiple tests
+      https://github.com/delfick/alt-pytest-asyncio/issues/26
+
 .. _release-0.9.2:
 
 0.9.2 - 23 February 2025

--- a/helpers/alt_pytest_asyncio_test_driver/examples/example_fixture_failures/expected
+++ b/helpers/alt_pytest_asyncio_test_driver/examples/example_fixture_failures/expected
@@ -1,5 +1,5 @@
 =======* ERRORS =====*
-_______* ERROR at setup of test_fails_on_fixture_returns _____*
+_* ERROR at setup of test_fails_on_fixture_returns _*
 *test_fails.py:17: in fixture_returns
     await one*()
 *test_fails.py:8: in one
@@ -7,7 +7,7 @@ _______* ERROR at setup of test_fails_on_fixture_returns _____*
 *test_fails.py:12: in two
     raise ValueError*("WAT")
 E   ValueError: WAT
-_______* ERROR at setup of test_fails_on_fixture_yields _____*
+_* ERROR at setup of test_fails_on_fixture_yields _*
 *test_fails.py:22: in fixture_yields
     yield await one*()
 *test_fails.py:8: in one
@@ -15,7 +15,7 @@ _______* ERROR at setup of test_fails_on_fixture_yields _____*
 *test_fails.py:12: in two
     raise ValueError*("WAT")
 E   ValueError: WAT
-_______* ERROR at teardown of test_fails_on_fixture_fails_in_finally _____*
+_* ERROR at teardown of test_fails_on_fixture_fails_in_finally _*
 *test_fails.py:30: in fixture_fails_in_finally
     await one*()
 *test_fails.py:8: in one
@@ -23,4 +23,28 @@ _______* ERROR at teardown of test_fails_on_fixture_fails_in_finally _____*
 *test_fails.py:12: in two
     raise ValueError*("WAT")
 E   ValueError: WAT
-=======* 1 passed, 3 error* in * ===*
+_* ERROR at setup of test_fails_fixture_failure_does_not_linger_first_iterator _*
+example_fixture_failures/test_fails.py:45: in fixture_fails_once_iterator
+    yield await one()
+example_fixture_failures/test_fails.py:8: in one
+    await two()
+example_fixture_failures/test_fails.py:12: in two
+    raise ValueError*("WAT")
+E   ValueError: WAT
+_* ERROR at setup of test_fails_fixture_failure_does_not_linger_first_result _*
+example_fixture_failures/test_fails.py:55: in fixture_fails_once_result
+    await one()
+example_fixture_failures/test_fails.py:8: in one
+    await two()
+example_fixture_failures/test_fails.py:12: in two
+    raise ValueError*("WAT")
+E   ValueError: WAT
+_* ERROR at teardown of test_fails_fixture_failure_does_not_linger_first_finally _*
+example_fixture_failures/test_fails.py:68: in fixture_fails_once_finally
+    await one()
+example_fixture_failures/test_fails.py:8: in one
+    await two()
+example_fixture_failures/test_fails.py:12: in two
+    raise ValueError*("WAT")
+E   ValueError: WAT
+=======* 5 passed, 6 error* in * ===*

--- a/helpers/alt_pytest_asyncio_test_driver/examples/example_fixture_failures/test_fails.py
+++ b/helpers/alt_pytest_asyncio_test_driver/examples/example_fixture_failures/test_fails.py
@@ -30,6 +30,44 @@ async def fixture_fails_in_finally() -> AsyncGenerator[int]:
         await one()
 
 
+_done_iterator: bool = False
+_done_result: bool = False
+_done_finally: bool = False
+
+
+@pytest.fixture()
+async def fixture_fails_once_iterator() -> AsyncGenerator[None]:
+    global _done_iterator
+    if _done_iterator:
+        return
+
+    _done_iterator = True
+    yield await one()
+
+
+@pytest.fixture()
+async def fixture_fails_once_result() -> None:
+    global _done_result
+    if _done_result:
+        return
+
+    _done_result = True
+    await one()
+
+
+@pytest.fixture()
+async def fixture_fails_once_finally() -> AsyncGenerator[None]:
+    try:
+        yield
+    finally:
+        global _done_finally
+        if _done_finally:
+            return
+
+        _done_finally = True
+        await one()
+
+
 def test_fails_on_fixture_returns(fixture_returns: int) -> None:
     pass
 
@@ -39,4 +77,40 @@ def test_fails_on_fixture_yields(fixture_yields: int) -> None:
 
 
 def test_fails_on_fixture_fails_in_finally(fixture_fails_in_finally: int) -> None:
+    pass
+
+
+def test_fails_fixture_failure_does_not_linger_first_iterator(
+    fixture_fails_once_iterator: None,
+) -> None:
+    pass
+
+
+def test_fails_fixture_failure_does_not_linger_second_iterator(
+    fixture_fails_once_iterator: None,
+) -> None:
+    pass
+
+
+def test_fails_fixture_failure_does_not_linger_first_result(
+    fixture_fails_once_result: None,
+) -> None:
+    pass
+
+
+def test_fails_fixture_failure_does_not_linger_second_result(
+    fixture_fails_once_result: None,
+) -> None:
+    pass
+
+
+def test_fails_fixture_failure_does_not_linger_first_finally(
+    fixture_fails_once_finally: None,
+) -> None:
+    pass
+
+
+def test_fails_fixture_failure_does_not_linger_second_finally(
+    fixture_fails_once_finally: None,
+) -> None:
     pass


### PR DESCRIPTION
Fixes #26 

It appears that we were recycling errors and timeouts on the fixtures

This is an attempt to ensure that the async fixture conversion happens for each setup in the scope it exists in and so theoretically doesn't do that recyling.

At the end of the day what this plugin does is a bit dodgy because we are overriding .func on the fixture. I still don't see another way of doing this though....