### PR TITLE
Make plugin aware of PEP 669

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,11 @@ generator fixtures.
 Changelog
 ---------
 
+.. _release-0.9.4:
+
+0.9.4 - TBD
+    * Make the plugin aware of PEP 669 (`#33 <https://github.com/delfick/alt-pytest-asyncio/pull/33>`_)
+
 .. _release-0.9.3:
 
 0.9.3 - 14 April 2025


### PR DESCRIPTION
After [PEP 669](https://peps.python.org/pep-0669/) there is now a formal way to determine if a debugger is active, which replaces sys.gettrace.

Fixes #32