### PR TITLE
Stop using asyncio.get_event_loop_policy().get_event_loop()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/alt_pytest_asyncio/converter.py
+++ b/alt_pytest_asyncio/converter.py
@@ -259,7 +259,11 @@ class Converter:
             res.exception()
             return
 
-        loop = asyncio.get_event_loop_policy().get_event_loop()
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+
         task = loop.create_task(
             self._async_runner(async_timeout, func, args, kwargs), context=self._ctx
         )

--- a/alt_pytest_asyncio/loop_manager.py
+++ b/alt_pytest_asyncio/loop_manager.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import sys
-import warnings
 from collections.abc import Coroutine
 from types import TracebackType
 from typing import Self
@@ -51,9 +50,11 @@ class Loop(contextlib.AbstractContextManager["Loop"]):
         self._new_loop = new_loop
 
     def __enter__(self) -> Self:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            self._original_loop = asyncio.get_event_loop_policy().get_event_loop()
+        try:
+            self._original_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            # Seems there's no other way to know if there is a current loop....
+            pass
 
         if self._new_loop:
             self.controlled_loop = asyncio.new_event_loop()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,11 @@ generator fixtures.
 Changelog
 ---------
 
+.. _release-0.9.6:
+
+0.9.6 - TBD
+    * Remove use of deprecated asyncio functionality that breaks the plugin under Python3.14
+
 .. _release-0.9.5:
 
 0.9.5 - 19 February 2026

--- a/helpers/alt_pytest_asyncio_test_driver/examples/example_fixture_failures/expected
+++ b/helpers/alt_pytest_asyncio_test_driver/examples/example_fixture_failures/expected
@@ -40,7 +40,7 @@ example_fixture_failures/test_fails.py:12: in two
     raise ValueError*("WAT")
 E   ValueError: WAT
 _* ERROR at teardown of test_fails_fixture_failure_does_not_linger_first_finally _*
-example_fixture_failures/test_fails.py:68: in fixture_fails_once_finally
+example_fixture_failures/test_fails.py:66: in fixture_fails_once_finally
     await one()
 example_fixture_failures/test_fails.py:8: in one
     await two()

--- a/helpers/alt_pytest_asyncio_test_driver/examples/example_fixture_failures/test_fails.py
+++ b/helpers/alt_pytest_asyncio_test_driver/examples/example_fixture_failures/test_fails.py
@@ -61,11 +61,9 @@ async def fixture_fails_once_finally() -> AsyncGenerator[None]:
         yield
     finally:
         global _done_finally
-        if _done_finally:
-            return
-
-        _done_finally = True
-        await one()
+        if not _done_finally:
+            _done_finally = True
+            await one()
 
 
 def test_fails_on_fixture_returns(fixture_returns: int) -> None:

--- a/tests/test_loop_manager.py
+++ b/tests/test_loop_manager.py
@@ -7,7 +7,10 @@ from alt_pytest_asyncio import Loop
 
 
 def get_event_loop() -> asyncio.AbstractEventLoop:
-    return asyncio.get_event_loop_policy().get_event_loop()
+    try:
+        return asyncio.get_event_loop()
+    except RuntimeError:
+        return asyncio.new_event_loop()
 
 
 @pytest.fixture()
@@ -118,7 +121,7 @@ class TestNoNewLoop:
         with Loop(new_loop=False) as custom_loop:
             msg = "There is no current event loop in thread.*"
             try:
-                assert get_event_loop() is None
+                assert asyncio.get_event_loop() is None
                 assert False, "should have risen an error"
             except Exception as error:
                 assert str(error).startswith("There is no current event loop in thread")


### PR DESCRIPTION
This was preventing the plugin from working under Python3.14

Fixes #44